### PR TITLE
Rock 5B: Autodetect memory size

### DIFF
--- a/edk2-platforms/Platform/Radxa/ROCK5B/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.c
+++ b/edk2-platforms/Platform/Radxa/ROCK5B/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.c
@@ -50,6 +50,7 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/PrintLib.h>
+#include <Library/SdramLib.h>
 #define ASSET_TAG_STR_STORAGE_SIZE  33
 #define SMB_IS_DIGIT(c)  (((c) >= '0') && ((c) <= '9'))
 
@@ -1023,7 +1024,7 @@ MemArrMapInfoUpdateSmbiosType19 (
   // The memory layout used in all known Pi SoC's starts at 0
   mMemArrMapInfoType19.StartingAddress = 0;
   mMemArrMapInfoType19.EndingAddress = 1024 * 1024;
-  mMemArrMapInfoType19.EndingAddress = 8192 * 1024;
+  mMemArrMapInfoType19.EndingAddress = SdramGetMemorySize () / 1024;
   mMemArrMapInfoType19.EndingAddress -= 1;
 
   LogSmbiosData ((EFI_SMBIOS_TABLE_HEADER*)&mMemArrMapInfoType19, mMemArrMapInfoType19Strings, NULL);

--- a/edk2-platforms/Platform/Radxa/ROCK5B/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.inf
+++ b/edk2-platforms/Platform/Radxa/ROCK5B/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.inf
@@ -41,6 +41,7 @@
   DebugLib
   PrintLib
   TimeBaseLib
+  SdramLib
 
 [Protocols]
   gEfiSmbiosProtocolGuid           # PROTOCOL SOMETIMES_CONSUMED

--- a/edk2-platforms/Platform/Radxa/ROCK5B/Library/PlatformLib/PlatformLib.inf
+++ b/edk2-platforms/Platform/Radxa/ROCK5B/Library/PlatformLib/PlatformLib.inf
@@ -34,6 +34,7 @@
   MemoryAllocationLib
   PcdLib
   PrintLib
+  SdramLib
 
 [Sources.common]
   Rk3588.c
@@ -52,7 +53,6 @@
   gArmTokenSpaceGuid.PcdArmPrimaryCoreMask
   gArmTokenSpaceGuid.PcdArmPrimaryCore
   gArmTokenSpaceGuid.PcdFdSize
-  gRK3588TokenSpaceGuid.PcdTotalMemorySize
   
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate

--- a/edk2-platforms/Platform/Radxa/ROCK5B/Library/PlatformLib/Rk3588Mem.c
+++ b/edk2-platforms/Platform/Radxa/ROCK5B/Library/PlatformLib/Rk3588Mem.c
@@ -15,6 +15,7 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
 #include <Library/Rk3588Mem.h>
+#include <Library/SdramLib.h>
 
 UINT64 mSystemMemoryBase = FixedPcdGet64 (PcdSystemMemoryBase);
 STATIC UINT64 mSystemMemorySize = FixedPcdGet64 (PcdSystemMemorySize);
@@ -45,8 +46,8 @@ ArmPlatformGetVirtualMemoryMap (
   UINTN                         Index = 0;
   ARM_MEMORY_REGION_DESCRIPTOR  *VirtualMemoryTable;
 
-  mSystemMemorySize = PcdGet64 (PcdTotalMemorySize);
-  DEBUG ((DEBUG_INFO, "RAM: 0x%ll08X (FIXED Size 0x%ll08X)\n", mSystemMemoryBase, mSystemMemorySize));
+  mSystemMemorySize = SdramGetMemorySize ();
+  DEBUG ((DEBUG_INFO, "RAM: 0x%ll08X (Size 0x%ll08X)\n", mSystemMemoryBase, mSystemMemorySize));
 
   VirtualMemoryTable = (ARM_MEMORY_REGION_DESCRIPTOR*)AllocatePages
                        (EFI_SIZE_TO_PAGES (sizeof (ARM_MEMORY_REGION_DESCRIPTOR) *

--- a/edk2-platforms/Platform/Radxa/ROCK5B/ROCK5B.dsc
+++ b/edk2-platforms/Platform/Radxa/ROCK5B/ROCK5B.dsc
@@ -90,6 +90,7 @@
   # Custom libraries
   #
   ArmPlatformLib|Platform/Radxa/ROCK5B/Library/PlatformLib/PlatformLib.inf
+  SdramLib|Silicon/Rockchip/Library/SdramLib/SdramLib.inf
   RockchipPlatformLib|Platform/Radxa/ROCK5B/Library/RockchipPlatformLib/RockchipPlatformLib.inf
   ResetSystemLib|Platform/Radxa/ROCK5B/Library/ResetSystemLib/ResetSystemLib.inf
   PlatformBootManagerLib|Platform/Radxa/ROCK5B/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -132,7 +133,6 @@
   # System Memory (1GB)
   gArmTokenSpaceGuid.PcdSystemMemoryBase|0x00000000
   gArmTokenSpaceGuid.PcdSystemMemorySize|0x40000000
-  gRK3588TokenSpaceGuid.PcdTotalMemorySize|0x200000000
   
   # RK3588 CPU profile
   gArmPlatformTokenSpaceGuid.PcdCoreCount|8

--- a/edk2-platforms/Silicon/Rockchip/Include/Library/SdramLib.h
+++ b/edk2-platforms/Silicon/Rockchip/Include/Library/SdramLib.h
@@ -1,0 +1,17 @@
+/** @file
+ *
+ *  Copyright (c) 2022, Jared McNeill <jmcneill@invisible.ca>
+ *
+ *  SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ **/
+
+#ifndef SDRAMLIB_H__
+#define SDRAMLIB_H__
+
+UINT64
+SdramGetMemorySize (
+    VOID
+    );
+
+#endif /* SDRAMLIB_H__ */

--- a/edk2-platforms/Silicon/Rockchip/Library/SdramLib/SdramLib.c
+++ b/edk2-platforms/Silicon/Rockchip/Library/SdramLib/SdramLib.c
@@ -1,0 +1,129 @@
+/** @file
+ *
+ *  SDRAM size detection for Rockchip SoCs
+ *
+ *  Copyright (c) 2022, Jared McNeill <jmcneill@invisible.ca>
+ *  Copyright (c) 2023, Gábor Stefanik <netrolller.3d@gmail.com>
+ *
+ *  SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ **/
+
+#include <Library/IoLib.h>
+#include <Library/DebugLib.h>
+#include <Library/SdramLib.h>
+
+// TODO convert these to PCDs
+#define SDRAM_OS_REG_BASE 0xFD58A208
+#define SDRAM_BANK_COUNT 2
+
+typedef enum {
+    SDRAM_DDR4 = 0,
+    SDRAM_DDR2 = 2,
+    SDRAM_DDR3 = 3,
+    SDRAM_LPDDR2 = 5,
+    SDRAM_LPDDR3 = 6,
+    SDRAM_LPDDR4 = 7,
+    SDRAM_LPDDR4X = 8,
+    SDRAM_LPDDR5 = 9,
+    SDRAM_DDR5 = 10
+} SDRAM_DDRTYPE;
+
+#define SYS_REG_DDRTYPE(x)              (((x) >> 13) & 0x7)
+#define SYS_REG_CHANNELNUM(x)           (((x) >> 12) & 0x1)
+#define SYS_REG_RANK_CH(x, c)           (((x) >> ((c) ? 27 : 11)) & 0x1)
+#define SYS_REG_COL_CH(x, c)            (((x) >> ((c) ? 25 : 9)) & 0x3)
+#define SYS_REG_BK_CH(x, c)             (((x) >> ((c) ? 24 : 8)) & 0x1)
+#define SYS_REG_CS0_ROW_CH_LO(x, c)     (((x) >> ((c) ? 22 : 6)) & 0x3)
+#define SYS_REG_CS1_ROW_CH_LO(x, c)     (((x) >> ((c) ? 20 : 4)) & 0x3)
+#define SYS_REG_BW_CH(x, c)             (((x) >> ((c) ? 18 : 2)) & 0x3)
+#define SYS_REG_ROW34_CH(x, c)          (((x) >> ((c) ? 31 : 30)) & 0x1)
+#define SYS_REG_DBW_CH(x, c)            (((x) >> ((c) ? 16 : 0)) & 0x3)
+
+#define SYS_REG1_VERSION(x)             (((x) >> 28) & 0xF)
+#define SYS_REG1_CS0_ROW_CH_HI(x, c)    (((x) >> ((c) ? 7 : 5)) & 0x1)
+#define SYS_REG1_CS1_ROW_CH_HI(x, c)    (((x) >> ((c) ? 6 : 4)) & 0x1)
+#define SYS_REG1_CS1_COL_CH(x, c)       (((x) >> ((c) ? 2 : 0)) & 0x3)
+
+UINT64
+SdramGetMemorySize (
+    VOID
+    )
+{
+    UINT32 OsReg;
+    UINT32 OsReg1;
+	INT32 Bank;
+    INT32 ChNum;
+    INT32 Ch;
+    INT32 Rank;
+    INT32 Cs0Col, Cs1Col;
+    INT32 Cs0Row, Cs1Row;
+    INT32 Bk;
+    INT32 Bw;
+    INT32 Row34;
+    INT32 Bg;
+    INT32 ChSizeMb;
+    INT32 SizeMb = 0;
+
+    for (Bank = 0; Bank < SDRAM_BANK_COUNT; Bank++) {
+
+        OsReg = MmioRead32 (SDRAM_OS_REG_BASE + 8 * Bank);
+        OsReg1 = MmioRead32 (SDRAM_OS_REG_BASE + 8 * Bank + 4);
+
+        ChNum = 1 + SYS_REG_CHANNELNUM(OsReg);
+
+        DEBUG ((DEBUG_INFO, "%a(): Bank #%d: %d channel(s), type 0x%X, version 0x%X\n",
+                __func__, Bank, ChNum, SYS_REG_DDRTYPE(OsReg), SYS_REG1_VERSION(OsReg1)));
+
+        for (Ch = 0; Ch < ChNum; Ch++) {
+            Rank = 1 + SYS_REG_RANK_CH(OsReg, Ch);
+            Cs0Col = 9 + SYS_REG_COL_CH(OsReg, Ch);
+            Cs1Col = Cs0Col;
+            Bk = 3 - SYS_REG_BK_CH(OsReg, Ch);
+            if (SYS_REG1_VERSION(OsReg1) >= 0x2) {
+                Cs1Col = 9 + SYS_REG1_CS1_COL_CH(OsReg1, Ch);
+                if (((SYS_REG1_CS0_ROW_CH_HI(OsReg1, Ch) << 2) +
+                      SYS_REG_CS0_ROW_CH_LO(OsReg, Ch)) == 7) {
+                    Cs0Row = 12;
+                } else {
+                    Cs0Row = 13 + (SYS_REG1_CS0_ROW_CH_HI(OsReg1, Ch) << 2) +
+                             SYS_REG_CS0_ROW_CH_LO(OsReg, Ch);
+                }
+                if (((SYS_REG1_CS1_ROW_CH_HI(OsReg1, Ch) << 2) +
+                      SYS_REG_CS1_ROW_CH_LO(OsReg, Ch)) == 7) {
+                    Cs1Row = 12;
+                } else {
+                    Cs1Row = 13 + (SYS_REG1_CS1_ROW_CH_HI(OsReg1, Ch) << 2) +
+                             SYS_REG_CS1_ROW_CH_LO(OsReg, Ch);
+                }
+            } else {
+                Cs0Row = 13 + SYS_REG_CS0_ROW_CH_LO(OsReg, Ch);
+                Cs1Row = 13 + SYS_REG_CS1_ROW_CH_LO(OsReg, Ch);
+            }
+            Bw = 2 >> SYS_REG_BW_CH(OsReg, Ch);
+            Row34 = SYS_REG_ROW34_CH(OsReg, Ch);
+            if (SYS_REG_DDRTYPE(OsReg) == SDRAM_DDR4 && SYS_REG1_VERSION(OsReg1) != 0x3) {
+                Bg = SYS_REG_DBW_CH(OsReg, Ch) == 2 ? 2 : 1;
+            } else {
+                Bg = 0;
+            }
+
+            ChSizeMb = 1 << (Cs0Row + Cs0Col + Bk + Bg + Bw - 20);
+            if (Rank > 1) {
+                ChSizeMb += ChSizeMb >> ((Cs0Row - Cs1Row) + (Cs0Col - Cs1Col));
+            }
+            if (Row34) {
+                ChSizeMb = ChSizeMb * 3 / 4;
+            }
+
+            DEBUG ((DEBUG_INFO, "%a(): Ch #%d: %u MB\n", __func__, Ch + Bank * 2, ChSizeMb));
+            SizeMb += ChSizeMb;
+        }
+	}
+
+    DEBUG ((DEBUG_INFO, "%a(): Detected %u MB RAM\n", __func__, SizeMb));
+
+    ASSERT (SizeMb != 0);
+
+    return (UINT64)SizeMb * 1024 * 1024;
+}

--- a/edk2-platforms/Silicon/Rockchip/Library/SdramLib/SdramLib.inf
+++ b/edk2-platforms/Silicon/Rockchip/Library/SdramLib/SdramLib.inf
@@ -1,0 +1,36 @@
+#/** @file
+#
+#  Rockchip SDRAM Library.
+#
+#  Copyright (c) 2022, Jared McNeill <jmcneill@invisible.ca>
+#  Copyright (c) 2023, Gábor Stefanik <netrolller.3d@gmail.com>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = SdramLib
+  FILE_GUID                      = F1722CDD-AB5E-4341-8E98-C04CA151D5FB
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = SdramLib
+
+[Sources]
+  SdramLib.c
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  MdePkg/MdePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  Silicon/Rockchip/Rk3588/Rk3588.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  IoLib
+
+[FixedPcd]
+
+[Guids]


### PR DESCRIPTION
Get rid of the hardcoded 8GB value.

SdramLib is intended to be generic, but the base address & bank count are still defined in code. They will need to be converted to PCDs to be truly generic.