### PR TITLE
Platforms: Add initial support for NanoPC T6

### DIFF
--- a/configs/nanopc-t6.conf
+++ b/configs/nanopc-t6.conf
@@ -1,0 +1,3 @@
+DSC_FILE=edk2-platforms/Platform/FriendlyElec/NanoPC-T6/NanoPC-T6.dsc
+PLATFORM_NAME=NanoPC-T6
+SOC=RK3588

--- a/edk2-platforms/Platform/FriendlyElec/NanoPC-T6/AcpiTables/AcpiTables.inf
+++ b/edk2-platforms/Platform/FriendlyElec/NanoPC-T6/AcpiTables/AcpiTables.inf
@@ -1,0 +1,64 @@
+#/** @file
+#
+#  ACPI table data and ASL sources required to boot the platform.
+#
+#  Copyright (c) 2019-2021, ARM Limited. All rights reserved.
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = AcpiTables
+  FILE_GUID                      = 7E374E25-8E01-4FEE-87F2-390C23C606CD
+  MODULE_TYPE                    = USER_DEFINED
+  VERSION_STRING                 = 1.0
+  RK_COMMON_ACPI_DIR             = Silicon/Rockchip/RK3588/AcpiTables
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = AARCH64
+#
+
+[Sources]
+  Dsdt.asl
+  $(RK_COMMON_ACPI_DIR)/Madt.aslc
+  $(RK_COMMON_ACPI_DIR)/Fadt.aslc
+  $(RK_COMMON_ACPI_DIR)/Gtdt.aslc
+  $(RK_COMMON_ACPI_DIR)/Spcr.aslc
+  $(RK_COMMON_ACPI_DIR)/Mcfg.aslc
+  $(RK_COMMON_ACPI_DIR)/RK3588PcieIort.aslc
+  $(RK_COMMON_ACPI_DIR)/Dbg2.aslc
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  ArmPlatformPkg/ArmPlatformPkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  Silicon/Rockchip/RockchipPkg.dec
+  Platform/Rockchip/RK3588/RK3588.dec
+
+[FixedPcd]
+  gArmTokenSpaceGuid.PcdArmArchTimerIntrNum
+  gArmTokenSpaceGuid.PcdArmArchTimerHypIntrNum
+  gArmTokenSpaceGuid.PcdArmArchTimerSecIntrNum
+  gArmTokenSpaceGuid.PcdArmArchTimerVirtIntrNum
+  gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase
+  gArmTokenSpaceGuid.PcdGicDistributorBase
+  gArmTokenSpaceGuid.PcdGicRedistributorsBase
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4CfgBaseAddress
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4ApbBaseAddress
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4DbiBaseAddress
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4CfgBaseAddress
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4CfgSize
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4IoBaseAddress
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4IoSize
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4MemBaseAddress
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4MemSize
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4MemBaseAddress64
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4MemSize64
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase

--- a/edk2-platforms/Platform/FriendlyElec/NanoPC-T6/AcpiTables/Dsdt.asl
+++ b/edk2-platforms/Platform/FriendlyElec/NanoPC-T6/AcpiTables/Dsdt.asl
@@ -1,0 +1,39 @@
+/** @file
+ *
+ *  Differentiated System Definition Table (DSDT)
+ *
+ *  Copyright (c) 2020, Pete Batard <pete@akeo.ie>
+ *  Copyright (c) 2018-2020, Andrey Warkentin <andrey.warkentin@gmail.com>
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Copyright (c) 2021, ARM Limited. All rights reserved.
+ *
+ *  SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ **/
+
+#include "AcpiTables.h"
+
+DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RPIFDN", "RPI", 2)
+{
+  Scope (\_SB_)
+  {
+    include ("Cpu.asl")
+
+    include ("Pcie.asl")
+    // include ("Sata.asl")
+    include ("Emmc.asl")
+    include ("Sdhc.asl")
+    // include ("Gmac.asl")
+    // include ("Gpio.asl")
+    // include ("I2c.asl")
+    include ("Uart.asl")
+    // include ("Spi.asl")
+
+    // won't work on Windows, will trigger bugcheck by usbehci
+    // include ("Usb2.asl")
+
+    include ("Usb3Host0.asl")
+    include ("Usb3Host1.asl")
+    // include ("Usb3Host2.asl")
+  }
+}

--- a/edk2-platforms/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-platforms/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -1,0 +1,297 @@
+/** @file
+*
+*  Copyright (c) 2021, Rockchip Limited. All rights reserved.
+*
+*  SPDX-License-Identifier: BSD-2-Clause-Patent
+*
+**/
+#include <Base.h>
+#include <Library/DebugLib.h>
+#include <Library/IoLib.h>
+#include <Library/GpioLib.h>
+#include <Library/RK806.h>
+#include <Soc.h>
+
+static struct regulator_init_data rk806_init_data[] = {
+  /* Master PMIC */
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK1, 750000),
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK3, 750000),
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK4, 750000),
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK5, 850000),
+  //RK8XX_VOLTAGE_INIT(MASTER_BUCK6, 750000),
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK7, 2000000),
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK8, 3300000),
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK10, 1800000),
+
+  RK8XX_VOLTAGE_INIT(MASTER_NLDO1, 750000),
+  RK8XX_VOLTAGE_INIT(MASTER_NLDO2, 850000),
+  RK8XX_VOLTAGE_INIT(MASTER_NLDO3, 750000),
+  RK8XX_VOLTAGE_INIT(MASTER_NLDO4, 850000),
+  RK8XX_VOLTAGE_INIT(MASTER_NLDO5, 750000),
+
+  RK8XX_VOLTAGE_INIT(MASTER_PLDO1, 1800000),
+  RK8XX_VOLTAGE_INIT(MASTER_PLDO2, 1800000),
+  RK8XX_VOLTAGE_INIT(MASTER_PLDO3, 1200000),
+  RK8XX_VOLTAGE_INIT(MASTER_PLDO4, 3300000),
+  RK8XX_VOLTAGE_INIT(MASTER_PLDO5, 3300000),
+  RK8XX_VOLTAGE_INIT(MASTER_PLDO6, 1800000),
+
+  /* No dual PMICs on this platform */
+};
+
+VOID
+EFIAPI
+DwEmmcDxeIoMux (
+  VOID
+  )
+{
+  /* sdmmc0 iomux (microSD socket) */
+  BUS_IOC->GPIO4D_IOMUX_SEL_L = (0xFFFFUL << 16) | (0x1111); //SDMMC_D0,SDMMC_D1,SDMMC_D2,SDMMC_D3
+  BUS_IOC->GPIO4D_IOMUX_SEL_H = (0x00FFUL << 16) | (0x0011); //SDMMC_CLK,SDMMC_CMD
+  PMU1_IOC->GPIO0A_IOMUX_SEL_H = (0x000FUL << 16) | (0x0001); //SDMMC_DET
+}
+
+VOID
+EFIAPI
+SdhciEmmcDxeIoMux (
+  VOID
+  )
+{
+  /* sdhci0 iomux (eMMC socket) */
+  BUS_IOC->GPIO2A_IOMUX_SEL_L = (0xFFFFUL << 16) | (0x1111); //EMMC_CMD,EMMC_CLKOUT,EMMC_DATASTROBE,EMMC_RSTN
+  BUS_IOC->GPIO2D_IOMUX_SEL_L = (0xFFFFUL << 16) | (0x1111); //EMMC_D0,EMMC_D1,EMMC_D2,EMMC_D3
+  BUS_IOC->GPIO2D_IOMUX_SEL_H = (0xFFFFUL << 16) | (0x1111); //EMMC_D4,EMMC_D5,EMMC_D6,EMMC_D7
+}
+
+#define NS_CRU_BASE         0xFD7C0000
+#define CRU_CLKSEL_CON59    0x03EC
+#define CRU_CLKSEL_CON78    0x0438
+
+VOID
+EFIAPI
+Rk806SpiIomux (
+  VOID
+  )
+{
+  /* io mux */
+  //BUS_IOC->GPIO1A_IOMUX_SEL_H = (0xFFFFUL << 16) | 0x8888;
+  //BUS_IOC->GPIO1B_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+  PMU1_IOC->GPIO0A_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0110;
+  PMU1_IOC->GPIO0B_IOMUX_SEL_L = (0xF0FFUL << 16) | 0x1011;
+  MmioWrite32(NS_CRU_BASE + CRU_CLKSEL_CON59, (0x00C0UL << 16) | 0x0080);
+}
+
+VOID
+EFIAPI
+Rk806Configure (
+  VOID
+  )
+{
+  UINTN RegCfgIndex;
+
+  RK806Init();
+
+  for (RegCfgIndex = 0; RegCfgIndex < ARRAY_SIZE(rk806_init_data); RegCfgIndex++)
+    RK806RegulatorInit(rk806_init_data[RegCfgIndex]);
+}
+
+VOID
+EFIAPI
+SetCPULittleVoltage (
+  IN UINT32 Microvolts
+  )
+{
+  struct regulator_init_data Rk806CpuLittleSupply =
+        RK8XX_VOLTAGE_INIT(MASTER_BUCK2, Microvolts);
+
+  RK806RegulatorInit(Rk806CpuLittleSupply);
+}
+
+VOID
+EFIAPI
+NorFspiIomux (
+  VOID
+  )
+{
+  /* io mux */
+  MmioWrite32(NS_CRU_BASE + CRU_CLKSEL_CON78,
+             (((0x3 << 12) | (0x3f << 6)) << 16) | (0x0 << 12) | (0x3f << 6));
+#define FSPI_M1
+#if defined(FSPI_M0)
+   /*FSPI M0*/
+  BUS_IOC->GPIO2A_IOMUX_SEL_L = ((0xF << 0) << 16) | (2 << 0); //FSPI_CLK_M0
+  BUS_IOC->GPIO2D_IOMUX_SEL_L = (0xFFFFUL << 16) | (0x2222); //FSPI_D0_M0,FSPI_D1_M0,FSPI_D2_M0,FSPI_D3_M0
+  BUS_IOC->GPIO2D_IOMUX_SEL_H = ((0xF << 8) << 16) | (0x2 << 8); //FSPI_CS0N_M0
+#elif defined(FSPI_M1)
+  /*FSPI M1*/
+  BUS_IOC->GPIO2A_IOMUX_SEL_H = (0xFF00UL << 16) | (0x3300); //FSPI_D0_M1,FSPI_D1_M1
+  BUS_IOC->GPIO2B_IOMUX_SEL_L = (0xF0FFUL << 16) | (0x3033); //FSPI_D2_M1,FSPI_D3_M1,FSPI_CLK_M1
+  BUS_IOC->GPIO2B_IOMUX_SEL_H = (0xF << 16) | (0x3); //FSPI_CS0N_M1
+#else
+  /*FSPI M2*/
+  BUS_IOC->GPIO3A_IOMUX_SEL_L = (0xFFFFUL << 16) | (0x5555); //[FSPI_D0_M2-FSPI_D3_M2]
+  BUS_IOC->GPIO3A_IOMUX_SEL_H = (0xF0UL << 16) | (0x50); //FSPI_CLK_M2
+  BUS_IOC->GPIO3C_IOMUX_SEL_H = (0xF << 16) | (0x2); //FSPI_CS0_M2
+#endif
+}
+
+VOID
+EFIAPI
+GmacIomux (
+   UINT32 id
+  )
+{
+  switch (id) {
+  case 0:
+    /* gmac0 iomux */
+    BUS_IOC->GPIO2A_IOMUX_SEL_H = (0xFF00UL << 16) | 0x1100;
+    BUS_IOC->GPIO2B_IOMUX_SEL_L = (0xFFFFUL << 16) | 0x1111;
+    BUS_IOC->GPIO2B_IOMUX_SEL_H = (0xFF00UL << 16) | 0x1100;
+    BUS_IOC->GPIO2C_IOMUX_SEL_L = (0xFFFFUL << 16) | 0x1111;
+    BUS_IOC->GPIO4C_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0100;
+    BUS_IOC->GPIO4C_IOMUX_SEL_H = (0x00FFUL << 16) | 0x0011;
+    break;
+  case 1:
+    /* gmac1 iomux */
+    break;
+  default:
+    break;
+  }
+}
+
+VOID
+EFIAPI
+NorFspiEnableClock (
+  UINT32 *CruBase
+  )
+{
+  UINTN BaseAddr = (UINTN) CruBase;
+
+  MmioWrite32(BaseAddr + 0x087C, 0x0E000000);
+}
+
+VOID
+EFIAPI
+I2cIomux (
+   UINT32 id
+  )
+{
+  switch (id) {
+  case 0:
+    /* io mux M2 */
+    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
+    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    break;
+  case 1:
+    /* io mux */
+    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
+    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    break;
+  case 2:
+    /* io mux */
+    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
+    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
+    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
+    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    break;
+  case 3:
+    break;
+  case 4:
+    break;
+  case 5:
+    break;
+  default:
+    break;
+  }
+}
+
+VOID
+EFIAPI
+UsbPortPowerEnable (
+  VOID
+  )
+{
+  DEBUG((EFI_D_WARN, "UsbPortPowerEnable called\n"));
+  /* Set GPIO4 PB0 (USB_HOST_PWREN) output high to power USB ports */
+  GpioPinWrite (4, GPIO_PIN_PB0, TRUE);
+  GpioPinSetDirection (4, GPIO_PIN_PB0, GPIO_PIN_OUTPUT);
+
+  /* Set GPIO1 PD2 (TYPEC5V_PWREN) output high to power the type-c port */
+  GpioPinWrite (1, GPIO_PIN_PD2, TRUE);
+  GpioPinSetDirection (1, GPIO_PIN_PD2, GPIO_PIN_OUTPUT);
+
+  // DEBUG((EFI_D_WARN, "Trying to enable on-board LED1\n"));
+  // GpioPinWrite (2, GPIO_PIN_PC0, TRUE);
+  // GpioPinSetDirection (2, GPIO_PIN_PC0, GPIO_PIN_OUTPUT);
+}
+
+VOID
+EFIAPI
+Usb2PhyResume (
+  VOID
+  )
+{
+  MmioWrite32(0xfd5d0008, 0x20000000);
+  MmioWrite32(0xfd5d4008, 0x20000000);
+  MmioWrite32(0xfd5d8008, 0x20000000);
+  MmioWrite32(0xfd5dc008, 0x20000000);
+  MmioWrite32(0xfd7f0a10, 0x07000700);
+  MmioWrite32(0xfd7f0a10, 0x07000000);
+}
+
+VOID
+EFIAPI
+UsbDpPhyEnable (
+  VOID
+  )
+{
+  /* enable rx_lfps_en & usbdp_low_pwrn */
+  MmioWrite32(0xfd5c8004, 0x60006000);
+  MmioWrite32(0xfd5cc004, 0x60006000);
+  
+  /* remove rx-termination, we don't support SS yet */
+  MmioWrite32 (0xfd5c800c, 0x00030001);
+  MmioWrite32 (0xfd5cc00c, 0x00030001);
+}
+
+VOID
+EFIAPI
+Pcie30IoInit (
+  VOID
+  )
+{
+  /* Set reset and power IO to gpio output mode */
+  GpioPinSetDirection (4, GPIO_PIN_PB6, GPIO_PIN_OUTPUT);
+  GpioPinSetDirection (2, GPIO_PIN_PC5, GPIO_PIN_OUTPUT);
+}
+
+VOID
+EFIAPI
+Pcie30PowerEn (
+  VOID
+  )
+{
+  /* output high to enable power */
+  GpioPinWrite (2, GPIO_PIN_PC5, TRUE);
+}
+
+VOID
+EFIAPI
+Pcie30PeReset (
+  BOOLEAN enable
+  )
+{
+  if(enable)
+    GpioPinWrite (4, GPIO_PIN_PB6, FALSE); /* output low */
+  else
+    GpioPinWrite (4, GPIO_PIN_PB6, TRUE); /* output high */
+}
+
+VOID
+EFIAPI
+PlatformEarlyInit (
+  VOID
+  )
+{
+  // Configure various things specific to this platform
+}

--- a/edk2-platforms/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.inf
+++ b/edk2-platforms/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.inf
@@ -1,0 +1,43 @@
+#
+#  Copyright (c) 2021, Rockchip Limited. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+[Defines]
+  INF_VERSION                    = 0x00010019
+  BASE_NAME                      = RockchipPlatformLib
+  FILE_GUID                      = 5178fa86-2fec-11ec-95b4-f42a7dcb925d
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = RockchipPlatformLib
+  RKPLATLIB_COMMON_DIR           = Silicon/Rockchip/RK3588/Library/RockchipPlatformLibCommon
+
+[Packages]
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  Platform/Rockchip/RK3588/RK3588.dec
+  Silicon/Rockchip/RK3588/RK3588.dec
+  Silicon/Rockchip/RockchipPkg.dec
+
+[LibraryClasses]
+  ArmLib
+  HobLib
+  IoLib
+  MemoryAllocationLib
+  SerialPortLib
+  CruLib
+  GpioLib
+
+[Sources.common]
+  RockchipPlatformLib.c
+  $(RKPLATLIB_COMMON_DIR)/RK3588CruLib.c
+  $(RKPLATLIB_COMMON_DIR)/RockchipSdhci.c
+
+[Sources.AARCH64]
+
+[Pcd]
+  gRockchipTokenSpaceGuid.PcdSdhciDxeBaseAddress
+  gRockchipTokenSpaceGuid.PcdI2cBusCount
+

--- a/edk2-platforms/Platform/FriendlyElec/NanoPC-T6/NanoPC-T6.dsc
+++ b/edk2-platforms/Platform/FriendlyElec/NanoPC-T6/NanoPC-T6.dsc
@@ -1,0 +1,616 @@
+#
+#  Copyright (c) 2014-2018, Linaro Limited. All rights reserved.
+#  Copyright (c) 2021-2022, Rockchip Limited. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+################################################################################
+#
+# Defines Section - statements that will be processed to create a Makefile.
+#
+################################################################################
+[Defines]
+  PLATFORM_NAME                  = NanoPC-T6
+  PLATFORM_GUID                  = d080df36-45e7-11ec-9726-f42a7dcb925d
+  PLATFORM_VERSION               = 0.2
+  DSC_SPECIFICATION              = 0x00010019
+  OUTPUT_DIRECTORY               = Build/$(PLATFORM_NAME)
+  SUPPORTED_ARCHITECTURES        = AARCH64
+  BUILD_TARGETS                  = DEBUG|RELEASE
+  SKUID_IDENTIFIER               = DEFAULT
+  FLASH_DEFINITION               = Platform/FriendlyElec/NanoPC-T6/NanoPC-T6.fdf
+
+  DEFINE CONFIG_NO_DEBUGLIB      = TRUE
+
+  DEFINE CP_UNCONNECTED    = 0x0
+  DEFINE CP_PCIE           = 0x01
+  DEFINE CP_SATA           = 0x10
+  DEFINE CP_USB3           = 0x20
+
+  #
+  # Network definition
+  #
+  DEFINE NETWORK_SNP_ENABLE             = FALSE
+  DEFINE NETWORK_IP6_ENABLE             = FALSE
+  DEFINE NETWORK_TLS_ENABLE             = FALSE
+  DEFINE NETWORK_HTTP_BOOT_ENABLE       = FALSE
+  DEFINE NETWORK_ISCSI_ENABLE           = FALSE
+  DEFINE NETWORK_VLAN_ENABLE            = FALSE
+!include Silicon/Rockchip/Rockchip.dsc.inc
+!include MdePkg/MdeLibs.dsc.inc
+
+!if $(ENABLE_SIMPLE_INIT)
+  !include SimpleInit.inc
+!endif
+
+[LibraryClasses.common]
+  ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
+  ArmPlatformLib|Silicon/Rockchip/RK3588/Library/PlatformLib/PlatformLib.inf
+  AcpiLib|EmbeddedPkg/Library/AcpiLib/AcpiLib.inf
+  CruLib|Silicon/Rockchip/Library/CruLib/CruLib.inf
+
+  DmaLib|EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.inf
+
+  CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf
+  UefiBootManagerLib|MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+
+  CustomizedDisplayLib|MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.inf
+
+  # UiApp dependencies
+  ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
+  FileExplorerLib|MdeModulePkg/Library/FileExplorerLib/FileExplorerLib.inf
+  DxeServicesLib|MdePkg/Library/DxeServicesLib/DxeServicesLib.inf
+  BootLogoLib|MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf
+
+  #RealTimeClockLib|ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.inf
+  TimeBaseLib|EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.inf
+
+  # USB Requirements
+  UefiUsbLib|MdePkg/Library/UefiUsbLib/UefiUsbLib.inf
+
+  # PCIe
+  PciSegmentLib|MdePkg/Library/BasePciSegmentLibPci/BasePciSegmentLibPci.inf
+  PciHostBridgeLib|Silicon/Rockchip/Library/PciHostBridgeLib/PciHostBridgeLib.inf
+  PciExpressLib|Silicon/Rockchip/Library/PciExpressLib/PciExpressLib.inf
+  PciLib|MdePkg/Library/BasePciLibPciExpress/BasePciLibPciExpress.inf
+
+
+  # VariableRuntimeDxe Requirements
+  SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
+  AuthVariableLib|MdeModulePkg/Library/AuthVariableLibNull/AuthVariableLibNull.inf
+  TpmMeasurementLib|MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
+  VarCheckLib|MdeModulePkg/Library/VarCheckLib/VarCheckLib.inf
+
+  AndroidBootImgLib|edk2/EmbeddedPkg/Library/AndroidBootImgLib/AndroidBootImgLib.inf
+
+  RockchipDisplayLib|Silicon/Rockchip/Library/DisplayLib/RockchipDisplayLib.inf
+
+  UefiScsiLib|MdePkg/Library/UefiScsiLib/UefiScsiLib.inf
+  LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf
+
+  # OTP Library
+  OtpLib|Silicon/Rockchip/RK3588/Library/OtpLib/OtpLib.inf
+
+  #
+  # Custom libraries
+  #
+  RockchipPlatformLib|Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.inf
+  ResetSystemLib|Silicon/Rockchip/Library/ResetSystemLib/ResetSystemLib.inf
+  PlatformBootManagerLib|Silicon/Rockchip/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+  SerialPortLib|Silicon/Hisilicon/Library/Dw8250SerialPortLib/Dw8250SerialPortLib.inf
+  GpioLib|Silicon/Rockchip/RK3588/Library/GpioLib/GpioLib.inf
+  # SCMI Mailbox Transport Layer
+  ArmMtlLib|Silicon/Rockchip/Library/RkMtlLib/RkMtlLib.inf
+
+[LibraryClasses.common.SEC]
+  PrePiLib|EmbeddedPkg/Library/PrePiLib/PrePiLib.inf
+  ExtractGuidedSectionLib|EmbeddedPkg/Library/PrePiExtractGuidedSectionLib/PrePiExtractGuidedSectionLib.inf
+  HobLib|EmbeddedPkg/Library/PrePiHobLib/PrePiHobLib.inf
+  MemoryAllocationLib|EmbeddedPkg/Library/PrePiMemoryAllocationLib/PrePiMemoryAllocationLib.inf
+  MemoryInitPeiLib|Silicon/Rockchip/RK3588/Library/MemoryInitPeiLib/MemoryInitPeiLib.inf
+  PlatformPeiLib|ArmPlatformPkg/PlatformPei/PlatformPeiLib.inf
+  PrePiHobListPointerLib|ArmPlatformPkg/Library/PrePiHobListPointerLib/PrePiHobListPointerLib.inf
+
+[LibraryClasses.common.DXE_RUNTIME_DRIVER]
+  RockchipPlatformLib|Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.inf
+
+[BuildOptions]
+  GCC:*_*_*_PLATFORM_FLAGS = -I$(WORKSPACE)/Silicon/Rockchip/RK3588/Include -I$(WORKSPACE)/Platform/Rockchip/RK3588/Include -I$(WORKSPACE)/Silicon/Rockchip/Include
+
+################################################################################
+#
+# Pcd Section - list of all EDK II PCD Entries defined by this Platform
+#
+################################################################################
+
+[PcdsFeatureFlag.common]
+  #  If TRUE, Graphics Output Protocol will be installed on virtual handle created by ConsplitterDxe.
+  #  It could be set FALSE to save size.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdConOutGopSupport|TRUE
+
+[PcdsFixedAtBuild.common]
+  gEfiMdePkgTokenSpaceGuid.PcdDefaultTerminalType|4
+
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString|L"$(FIRMWARE_VER)"
+
+  # System Memory (1GB)
+  gArmTokenSpaceGuid.PcdSystemMemoryBase|0x00000000
+  gArmTokenSpaceGuid.PcdSystemMemorySize|0x40000000
+  
+  # RK3588 CPU profile
+  gArmPlatformTokenSpaceGuid.PcdCoreCount|8
+  gArmPlatformTokenSpaceGuid.PcdClusterCount|1
+
+  # SMBIOS platform config
+  gRockchipTokenSpaceGuid.PcdPlatformName|"NanoPC T6"
+  gRockchipTokenSpaceGuid.PcdPlatformVendorName|"FriendlyElec"
+  gRockchipTokenSpaceGuid.PcdFamilyName|"NanoPi 6"
+  gRockchipTokenSpaceGuid.PcdProductUrl|"https://wiki.friendlyelec.com/wiki/index.php/NanoPC-T6"
+  gRockchipTokenSpaceGuid.PcdMemoryVendorName|"TBD"
+
+  # I2C
+  gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43 }
+  gRockchipTokenSpaceGuid.PcdI2cSlaveBuses|{ 0x0, 0x0 }
+  gRockchipTokenSpaceGuid.PcdI2cControllersEnabled|{ 0x0 }
+  gRockchipTokenSpaceGuid.PcdI2cClockFrequency|198000000
+  gRockchipTokenSpaceGuid.PcdI2cBaudRate|100000
+  gRockchipTokenSpaceGuid.PcdI2cBusCount|1
+  gRockchipTokenSpaceGuid.PcdI2cDemoAddresses|{ 0x51 } #/* RTCYM8563TS 0x51@bus2 */
+  gRockchipTokenSpaceGuid.PcdI2cDemoBuses|{ 0x2 }
+  gRockchipTokenSpaceGuid.PcdRk860xRegulatorAddresses|{ 0x42, 0x43 }
+  gRockchipTokenSpaceGuid.PcdRk860xRegulatorBuses|{ 0x0, 0x0 }
+  gRockchipTokenSpaceGuid.PcdRk860xRegulatorTags|{ 2, 3 } # SCMI_CLK_CPUB01, SCMI_CLK_CPUB23
+  gRockchipTokenSpaceGuid.PcdRk860xRegulatorMinVoltages|{ UINT32(550000), UINT32(550000) }
+  gRockchipTokenSpaceGuid.PcdRk860xRegulatorMaxVoltages|{ UINT32(1050000), UINT32(1050000) }
+
+  ## UART2 - Serial Terminal
+  DEFINE SERIAL_BASE = 0xFEB50000 # UART2
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|$(SERIAL_BASE)
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate|1500000
+  gHisiTokenSpaceGuid.PcdSerialPortSendDelay|500000
+  gHisiTokenSpaceGuid.PcdUartClkInHz|24000000
+
+  ## SPI - SPI2 for test
+  gRockchipTokenSpaceGuid.SpiTestBaseAddr|0xFEB20000
+  gRockchipTokenSpaceGuid.SpiRK806BaseAddr|0xFEB20000
+  ## PL031 RealTimeClock
+  #gArmPlatformTokenSpaceGuid.PcdPL031RtcBase|0xF8003000
+
+  ## NOR FLASH
+  gRockchipTokenSpaceGuid.FspiBaseAddr|0xFE2B0000
+
+  ## CRU
+  gRockchipTokenSpaceGuid.CruBaseAddr|0xFD7C0000
+
+  #gRockchipTokenSpaceGuid.PcdSpiVariableOffset|0x3C0000
+  #
+  # ARM General Interrupt Controller
+  #
+  gArmTokenSpaceGuid.PcdGicDistributorBase|0xfe600000
+  gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase|0xfe600000
+  gArmTokenSpaceGuid.PcdGicRedistributorsBase|0xfe680000
+
+  gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|3
+
+  # GUID of the UI app
+  gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }
+
+  gEfiMdeModulePkgTokenSpaceGuid.PcdResetOnMemoryTypeInformationChange|FALSE
+
+  gEmbeddedTokenSpaceGuid.PcdMetronomeTickPeriod|1000
+
+  #
+  # DW SD card controller
+  #
+  gDesignWareTokenSpaceGuid.PcdDwEmmcDxeBaseAddress|0xfe2c0000
+  gDesignWareTokenSpaceGuid.PcdDwEmmcDxeClockFrequencyInHz|100000000
+  gDesignWareTokenSpaceGuid.PcdDwPermitObsoleteDrivers|TRUE
+  gDesignWareTokenSpaceGuid.PcdDwEmmcDxeFifoDepth|256
+  #
+  # SDHCI controller
+  #
+  gRockchipTokenSpaceGuid.PcdSdhciDxeBaseAddress|0xfe2e0000
+
+  #
+  # PCIe controller
+  #
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4ApbBaseAddress|0xfe150000
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4DbiBaseAddress|0xf5000000
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4CfgBaseAddress|0xf0000000
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4CfgSize|0x100000
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4IoBaseAddress|0xf0100000
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4IoSize|0x10000
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4MemBaseAddress|0xf0200000
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4MemSize|0xe00000
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4MemBaseAddress64|0x901000000 #deduct 0x1000000 ECAM space
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4MemSize64|0x3f000000
+
+  #
+  # Fastboot
+  #
+  gEmbeddedTokenSpaceGuid.PcdAndroidFastbootUsbVendorId|0x2207
+  gEmbeddedTokenSpaceGuid.PcdAndroidFastbootUsbProductId|0x0001
+
+  #
+  # USB2 EHCI + OHCI companion controllers
+  #
+  gRockchipTokenSpaceGuid.PcdEhciBaseAddress|0xfc800000
+  gRockchipTokenSpaceGuid.PcdNumEhciController|2
+  gRockchipTokenSpaceGuid.PcdEhciSize|0x40000
+  gRockchipTokenSpaceGuid.PcdOhciSize|0x40000
+
+  #
+  # DWC3 controller
+  #
+  gRockchipTokenSpaceGuid.PcdDwc3BaseAddresses|{ UINT32(0xfc000000), UINT32(0xfc400000) }
+  gRockchipTokenSpaceGuid.PcdDwc3Size|0x400000
+
+  #
+  # Android Loader
+  #
+  gRK3588TokenSpaceGuid.PcdAndroidBootDevicePath|L"\\EFI\\BOOT\\GRUBAA64.EFI"
+  gRK3588TokenSpaceGuid.PcdSdBootDevicePath|L"VenHw(0D51905B-B77E-452A-A2C0-ECA0CC8D514A,00E023F70000000000)/SD(0x0)"
+  gRK3588TokenSpaceGuid.PcdKernelBootArg|L"earlycon=uart8250,mmio32,0xfeb50000 root=PARTUUID=614e0000-0000 rw rootwait"
+  gEmbeddedTokenSpaceGuid.PcdAndroidBootDevicePath|L"VenHw(100C2CFA-B586-4198-9B4C-1683D195B1DA)/HD(3,GPT,7A3F0000-0000-446A-8000-702F00006273,0x8000,0x20000)"
+  #
+  # Make VariableRuntimeDxe work at emulated non-volatile variable mode.
+  #
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable|TRUE
+
+  # ACPI Enable
+  gRK3588TokenSpaceGuid.AcpiEnable|TRUE
+
+  #
+  # Display
+  #
+  gRockchipTokenSpaceGuid.PcdLcdPixelFormat|0x00000001
+  gRockchipTokenSpaceGuid.PcdEdpId|0x00000000 #edp0
+  #gRockchipTokenSpaceGuid.PcdEdpId|0x00000001 #edp1
+  gRockchipTokenSpaceGuid.PcdHdmiId|0x00000000 #hdmi0
+  #gRockchipTokenSpaceGuid.PcdHdmiId|0x00000001 #hdmi1
+
+  #
+  # ComboPhy
+  #
+  gRockchipTokenSpaceGuid.PcdComboPhyMode|{ $(CP_PCIE), $(CP_PCIE), $(CP_PCIE) }
+
+  #  BIT0  - Initialization message.<BR>
+  #  BIT1  - Warning message.<BR>
+  #  BIT2  - Load Event message.<BR>
+  #  BIT3  - File System message.<BR>
+  #  BIT4  - Allocate or Free Pool message.<BR>
+  #  BIT5  - Allocate or Free Page message.<BR>
+  #  BIT6  - Information message.<BR>
+  #  BIT7  - Dispatcher message.<BR>
+  #  BIT8  - Variable message.<BR>
+  #  BIT10 - Boot Manager message.<BR>
+  #  BIT12 - BlockIo Driver message.<BR>
+  #  BIT14 - Network Driver message.<BR>
+  #  BIT16 - UNDI Driver message.<BR>
+  #  BIT17 - LoadFile message.<BR>
+  #  BIT19 - Event message.<BR>
+  #  BIT20 - Global Coherency Database changes message.<BR>
+  #  BIT21 - Memory range cachability changes message.<BR>
+  #  BIT22 - Detailed debug message.<BR>
+  #  BIT31 - Error message.<BR>
+!if $(TARGET) == RELEASE
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0e
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80000000
+!else
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0f
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x800B0507
+!endif
+# 0x800B05C7
+# Use 0x807B55FF to enable all debug messages
+
+[PcdsDynamicDefault.common]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0x007C0000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase64|0x007CF000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64|0x007D0000
+
+  #
+  # Display
+  #
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution|0x780
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution|0x438
+  gEfiMdeModulePkgTokenSpaceGuid.PcdConOutRow|0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdConOutColumn|0
+
+[PcdsDynamicHii.common.DEFAULT]
+  #
+  # CPU Performance
+  #
+  gRK3588TokenSpaceGuid.PcdCPULClusterClockPreset|L"CpuPerf_CPULClusterClockPreset"|gRK3588DxeFormSetGuid|0x0|2
+  gRK3588TokenSpaceGuid.PcdCPULClusterClockCustom|L"CpuPerf_CPULClusterClockCustom"|gRK3588DxeFormSetGuid|0x0|1800
+  gRK3588TokenSpaceGuid.PcdCPUB01ClusterClockPreset|L"CpuPerf_CPUB01ClusterClockPreset"|gRK3588DxeFormSetGuid|0x0|2
+  gRK3588TokenSpaceGuid.PcdCPUB01ClusterClockCustom|L"CpuPerf_CPUB01ClusterClockCustom"|gRK3588DxeFormSetGuid|0x0|2400
+  gRK3588TokenSpaceGuid.PcdCPUB23ClusterClockPreset|L"CpuPerf_CPUB23ClusterClockPreset"|gRK3588DxeFormSetGuid|0x0|2
+  gRK3588TokenSpaceGuid.PcdCPUB23ClusterClockCustom|L"CpuPerf_CPUB23ClusterClockCustom"|gRK3588DxeFormSetGuid|0x0|2400
+  gRK3588TokenSpaceGuid.PcdCPULClusterVoltageMode|L"CpuPerf_CPULClusterVoltageMode"|gRK3588DxeFormSetGuid|0x0|0
+  gRK3588TokenSpaceGuid.PcdCPULClusterVoltageCustom|L"CpuPerf_CPULClusterVoltageCustom"|gRK3588DxeFormSetGuid|0x0|950000
+  gRK3588TokenSpaceGuid.PcdCPUB01ClusterVoltageMode|L"CpuPerf_CPUB01ClusterVoltageMode"|gRK3588DxeFormSetGuid|0x0|0
+  gRK3588TokenSpaceGuid.PcdCPUB01ClusterVoltageCustom|L"CpuPerf_CPUB01ClusterVoltageCustom"|gRK3588DxeFormSetGuid|0x0|1000000
+  gRK3588TokenSpaceGuid.PcdCPUB23ClusterVoltageMode|L"CpuPerf_CPUB23ClusterVoltageMode"|gRK3588DxeFormSetGuid|0x0|0
+  gRK3588TokenSpaceGuid.PcdCPUB23ClusterVoltageCustom|L"CpuPerf_CPUB23ClusterVoltageCustom"|gRK3588DxeFormSetGuid|0x0|1000000
+
+################################################################################
+#
+# Components Section - list of all EDK II Modules needed by this Platform
+#
+################################################################################
+[Components.common]
+  #
+  # PEI Phase modules
+  #
+  ArmPlatformPkg/PrePi/PeiUniCore.inf
+  MdeModulePkg/Core/Pei/PeiMain.inf
+  MdeModulePkg/Universal/PCD/Pei/Pcd.inf
+
+  #
+  # DXE
+  #
+  MdeModulePkg/Core/Dxe/DxeMain.inf {
+    <LibraryClasses>
+      NULL|MdeModulePkg/Library/DxeCrc32GuidedSectionExtractLib/DxeCrc32GuidedSectionExtractLib.inf
+  }
+
+  #
+  # Architectural Protocols
+  #
+  ArmPkg/Drivers/CpuDxe/CpuDxe.inf
+  MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
+  MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
+  MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
+  EmbeddedPkg/EmbeddedMonotonicCounter/EmbeddedMonotonicCounter.inf
+  MdeModulePkg/Universal/ResetSystemRuntimeDxe/ResetSystemRuntimeDxe.inf
+  #EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf
+  EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf {
+  <LibraryClasses>
+    RealTimeClockLib|EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.inf
+  }
+  EmbeddedPkg/MetronomeDxe/MetronomeDxe.inf
+
+  MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatformDxe.inf
+  MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitterDxe.inf
+  MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
+  MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsoleDxe.inf
+  MdeModulePkg/Universal/SerialDxe/SerialDxe.inf
+
+  #PCIe
+  Silicon/Rockchip/Library/PciExpressLib/PciExpressLib.inf
+  Silicon/Rockchip/Library/PciHostBridgeLib/PciHostBridgeLib.inf
+  Silicon/Rockchip/Drivers/PciPlatform/PcieInitDxe.inf
+  ArmPkg/Drivers/ArmPciCpuIo2Dxe/ArmPciCpuIo2Dxe.inf
+
+  MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
+  MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
+  MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
+  #MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPei.inf
+  MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.inf
+  MdeModulePkg/Bus/Pci/SataControllerDxe/SataControllerDxe.inf
+
+  MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.inf
+  
+
+  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
+
+  ArmPkg/Drivers/ArmGic/ArmGicDxe.inf
+  ArmPkg/Drivers/TimerDxe/TimerDxe.inf
+
+  MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.inf
+
+  MdeModulePkg/Universal/PCD/Dxe/Pcd.inf
+
+  Silicon/Rockchip/Drivers/Vop2Dxe/Vop2Dxe.inf
+  #Silicon/Rockchip/Library/DisplayLib/AnalogixDpLib.inf
+  Silicon/Rockchip/Library/DisplayLib/DwHdmiQpLib.inf
+  Silicon/Rockchip/Drivers/LcdGraphicsOutputDxe/LcdGraphicsOutputDxe.inf
+
+  #
+  # TianoCore logo (splash screen)
+  #
+  MdeModulePkg/Logo/LogoDxe.inf
+
+  #
+  # SCMI Driver
+  #
+  ArmPkg/Drivers/ArmScmiDxe/ArmScmiDxe.inf
+
+  #
+  # ACPI Support
+  #
+  MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
+  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
+  Platform/FriendlyElec/NanoPC-T6/AcpiTables/AcpiTables.inf
+
+  #
+  # Device tree
+  #
+  EmbeddedPkg/Drivers/DtPlatformDxe/DtPlatformDxe.inf {
+  <LibraryClasses>
+    DtPlatformDtbLoaderLib|EmbeddedPkg/Library/DxeDtPlatformDtbLoaderLibDefault/DxeDtPlatformDtbLoaderLibDefault.inf
+  }
+
+  #
+  # GPIO
+  #
+  Platform/Rockchip/RK3588/RK3588GpioDxe/RK3588GpioDxe.inf
+
+  #
+  # Virtual Keyboard
+  #
+  EmbeddedPkg/Drivers/VirtualKeyboardDxe/VirtualKeyboardDxe.inf
+
+  # I2C drivers
+  Silicon/Rockchip/Drivers/I2c/I2cDxe/I2cDxe.inf
+  MdeModulePkg/Bus/I2c/I2cDxe/I2cDxe.inf
+  Silicon/Rockchip/Drivers/I2c/I2cDemoDxe/I2cDemoDxe.inf
+  Silicon/Rockchip/Applications/I2cDemoTest/I2cDemoTest.inf
+  Silicon/Rockchip/Drivers/I2c/Rk860xRegulatorDxe/Rk860xRegulatorDxe.inf
+
+  #
+  # MMC/SD
+  #
+  #EmbeddedPkg/Universal/MmcDxe/MmcDxe.inf
+  #Silicon/Synopsys/DesignWare/Drivers/DwEmmcDxe/DwEmmcDxe.inf
+  Silicon/Rockchip/Drivers/MmcDxe/MmcDxe.inf
+  Silicon/Rockchip/RK3588/Drivers/DwEmmcDxe/DwEmmcDxe.inf
+  Silicon/Rockchip/Drivers/SdhciHostDxe/SdhciHostDxe.inf
+
+  #
+  # NOR FLASH
+  #
+  Silicon/Rockchip/Drivers/NorFlashDxe/NorFlashDxe.inf
+  Silicon/Rockchip/Drivers/NorFlashDxe/RkFvbDxe.inf
+  Silicon/Rockchip/Applications/SpiTool/SpiFlashCmd.inf
+
+  #
+  # AHCI Support
+  #
+  Silicon/Rockchip/Drivers/SataControllerDxe/SataControllerDxe.inf
+  Silicon/Rockchip/Drivers/AtaAtapiPassThru/AtaAtapiPassThru.inf
+  MdeModulePkg/Bus/Ata/AtaBusDxe/AtaBusDxe.inf
+
+  #
+  # SPI TEST
+  #
+  # Silicon/Rockchip/Library/SpiLib/SpiTest.inf
+
+  #
+  # SMBIOS Support
+  #
+  Silicon/Rockchip/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.inf
+  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf
+  
+  #
+  # USB Ohci Controller
+  #
+  Silicon/Rockchip/Drivers/OhciDxe/OhciDxe.inf
+
+  #
+  # USB Ehci Controller
+  #
+  MdeModulePkg/Bus/Pci/EhciDxe/EhciDxe.inf
+
+  #
+  # USB Dwc3 Controller
+  #
+  Silicon/Rockchip/Drivers/UsbHcdInitDxe/UsbHcd.inf
+
+  #
+  # USB Xhci Controller
+  #
+  MdeModulePkg/Bus/Pci/XhciDxe/XhciDxe.inf
+
+  #
+  # USB Host Support
+  #
+  MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBusDxe.inf
+
+  #
+  # USB Mass Storage Support
+  #
+  MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassStorageDxe.inf
+
+  #
+  # USB Kb Support
+  #
+  MdeModulePkg/Bus/Usb/UsbKbDxe/UsbKbDxe.inf
+
+  #
+  # USB Mouse Support
+  #
+  MdeModulePkg/Bus/Usb/UsbMouseDxe/UsbMouseDxe.inf
+
+  #
+  # USB MouseAbsolutePointer Support
+  #
+  MdeModulePkg/Bus/Usb/UsbMouseAbsolutePointerDxe/UsbMouseAbsolutePointerDxe.inf
+
+  #
+  # USB Peripheral Support
+  #
+  EmbeddedPkg/Drivers/AndroidFastbootTransportUsbDxe/FastbootTransportUsbDxe.inf
+
+  #
+  # Fastboot
+  #
+  EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.inf
+
+  #
+  # Android Boot applications
+  #
+  EmbeddedPkg/Application/AndroidBoot/AndroidBootApp.inf
+
+  #
+  # UEFI Network Stack
+  #
+!include NetworkPkg/Network.dsc.inc
+  #
+  # AX88772 Ethernet Driver
+  #
+  Drivers/ASIX/Bus/Usb/UsbNetworking/Ax88772c/Ax88772c.inf
+
+  #
+  # FAT filesystem + GPT/MBR partitioning
+  #
+  MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf
+  MdeModulePkg/Universal/Disk/PartitionDxe/PartitionDxe.inf
+  MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/EnglishDxe.inf
+  MdeModulePkg/Universal/FvSimpleFileSystemDxe/FvSimpleFileSystemDxe.inf
+  FatPkg/EnhancedFatDxe/Fat.inf
+
+  #
+  # Bds
+  #
+  MdeModulePkg/Universal/DevicePathDxe/DevicePathDxe.inf
+  MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf {
+    <LibraryClasses>
+      PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+  }
+  MdeModulePkg/Universal/SetupBrowserDxe/SetupBrowserDxe.inf
+  MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf
+  MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
+  MdeModulePkg/Application/UiApp/UiApp.inf {
+    <LibraryClasses>
+      NULL|MdeModulePkg/Library/DeviceManagerUiLib/DeviceManagerUiLib.inf
+      NULL|MdeModulePkg/Library/BootManagerUiLib/BootManagerUiLib.inf
+      NULL|MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenanceManagerUiLib.inf
+      PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+  }
+  ShellPkg/Application/Shell/Shell.inf {
+    <LibraryClasses>
+      ShellCommandLib|ShellPkg/Library/UefiShellCommandLib/UefiShellCommandLib.inf
+      NULL|ShellPkg/Library/UefiShellLevel2CommandsLib/UefiShellLevel2CommandsLib.inf
+      NULL|ShellPkg/Library/UefiShellLevel1CommandsLib/UefiShellLevel1CommandsLib.inf
+      NULL|ShellPkg/Library/UefiShellLevel3CommandsLib/UefiShellLevel3CommandsLib.inf
+      NULL|ShellPkg/Library/UefiShellDriver1CommandsLib/UefiShellDriver1CommandsLib.inf
+      NULL|ShellPkg/Library/UefiShellDebug1CommandsLib/UefiShellDebug1CommandsLib.inf
+      NULL|ShellPkg/Library/UefiShellInstall1CommandsLib/UefiShellInstall1CommandsLib.inf
+      NULL|Silicon/Rockchip/Applications/I2cDemoTest/I2cDemoTest.inf
+      NULL|Silicon/Rockchip/Applications/SpiTool/SpiFlashCmd.inf
+      NULL|ShellPkg/Library/UefiShellNetwork1CommandsLib/UefiShellNetwork1CommandsLib.inf
+      NULL|ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.inf
+      HandleParsingLib|ShellPkg/Library/UefiHandleParsingLib/UefiHandleParsingLib.inf
+      OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+      PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
+      BcfgCommandLib|ShellPkg/Library/UefiShellBcfgCommandLib/UefiShellBcfgCommandLib.inf
+    <PcdsFixedAtBuild>
+      gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0xFF
+      gEfiShellPkgTokenSpaceGuid.PcdShellLibAutoInitialize|FALSE
+      gEfiMdePkgTokenSpaceGuid.PcdUefiLibMaxPrintBufferSize|8000
+  }
+!ifdef $(INCLUDE_TFTP_COMMAND)
+  ShellPkg/DynamicCommand/TftpDynamicCommand/TftpDynamicCommand.inf
+!endif #$(INCLUDE_TFTP_COMMAND)
+
+  #
+  # Custom Applications and drivers
+  #
+  Silicon/Rockchip/Applications/MaskromReset/maskrom.inf
+
+  # Platform drivers
+  Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/RK3588Dxe.inf
+

--- a/edk2-platforms/Platform/FriendlyElec/NanoPC-T6/NanoPC-T6.fdf
+++ b/edk2-platforms/Platform/FriendlyElec/NanoPC-T6/NanoPC-T6.fdf
@@ -1,0 +1,384 @@
+#
+#  Copyright (c) 2014-2018, Linaro Limited. All rights reserved.
+#  Copyright (c) 2021-2022, Rockchip Limited. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+################################################################################
+#
+# FD Section
+# The [FD] Section is made up of the definition statements and a
+# description of what goes into  the Flash Device Image.  Each FD section
+# defines one flash "device" image.  A flash device image may be one of
+# the following: Removable media bootable image (like a boot floppy
+# image,) an Option ROM image (that would be "flashed" into an add-in
+# card,) a System "Flash"  image (that would be burned into a system's
+# flash) or an Update ("Capsule") image that will be used to update and
+# existing system flash.
+#
+################################################################################
+
+[FD.NOR_FLASH_IMAGE]
+BaseAddress   = 0x00000000|gArmTokenSpaceGuid.PcdFdBaseAddress  # The base address of the Firmware in NOR Flash.
+Size          = 0x00800000|gArmTokenSpaceGuid.PcdFdSize         # The size in bytes of the FLASH Device
+ErasePolarity = 1
+
+# This one is tricky, it must be: BlockSize * NumBlocks = Size
+BlockSize     = 0x00001000
+NumBlocks     = 0x800
+
+################################################################################
+#
+# Following are lists of FD Region layout which correspond to the locations of different
+# images within the flash device.
+#
+# Regions must be defined in ascending order and may not overlap.
+#
+# A Layout Region start with a eight digit hex offset (leading "0x" required) followed by
+# the pipe "|" character, followed by the size of the region, also in hex with the leading
+# "0x" characters. Like:
+# Offset|Size
+# PcdOffsetCName|PcdSizeCName
+# RegionType <FV, DATA, or FILE>
+#
+################################################################################
+0x00200000|0x00500000
+gArmTokenSpaceGuid.PcdFvBaseAddress|gArmTokenSpaceGuid.PcdFvSize
+FV = BL33_AP_UEFI
+
+# NV_VARIABLE_STORE
+0x007C0000|0x00010000
+gRockchipTokenSpaceGuid.PcdNvStorageVariableBase|gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize
+
+# NV_FTW_WORKING header
+0x007D0000|0x00010000
+gRockchipTokenSpaceGuid.PcdNvStorageFtwWorkingBase|gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingSize
+
+# NV_FTW_WORKING data
+0x007E0000|0x00010000
+gRockchipTokenSpaceGuid.PcdNvStorageFtwSpareBase|gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize
+
+################################################################################
+#
+# FV Section
+#
+# [FV] section is used to define what components or modules are placed within a flash
+# device file.  This section also defines order the components and modules are positioned
+# within the image.  The [FV] section consists of define statements, set statements and
+# module statements.
+#
+################################################################################
+
+[FV.FvMain]
+BlockSize          = 0x40
+NumBlocks          = 0         # This FV gets compressed so make it just big enough
+FvAlignment        = 8         # FV alignment and FV attributes setting.
+ERASE_POLARITY     = 1
+MEMORY_MAPPED      = TRUE
+STICKY_WRITE       = TRUE
+LOCK_CAP           = TRUE
+LOCK_STATUS        = TRUE
+WRITE_DISABLED_CAP = TRUE
+WRITE_ENABLED_CAP  = TRUE
+WRITE_STATUS       = TRUE
+WRITE_LOCK_CAP     = TRUE
+WRITE_LOCK_STATUS  = TRUE
+READ_DISABLED_CAP  = TRUE
+READ_ENABLED_CAP   = TRUE
+READ_STATUS        = TRUE
+READ_LOCK_CAP      = TRUE
+READ_LOCK_STATUS   = TRUE
+
+  APRIORI DXE {
+    INF MdeModulePkg/Universal/PCD/Dxe/Pcd.inf
+  }
+
+  INF MdeModulePkg/Core/Dxe/DxeMain.inf
+
+  #
+  # PI DXE Drivers producing Architectural Protocols (EFI Services)
+  #
+  INF ArmPkg/Drivers/CpuDxe/CpuDxe.inf
+  INF MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
+  INF MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
+  INF MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
+  INF EmbeddedPkg/EmbeddedMonotonicCounter/EmbeddedMonotonicCounter.inf
+  INF MdeModulePkg/Universal/ResetSystemRuntimeDxe/ResetSystemRuntimeDxe.inf
+  INF EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf
+  INF EmbeddedPkg/MetronomeDxe/MetronomeDxe.inf
+
+  #
+  # Multiple Console IO support
+  #
+  INF MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatformDxe.inf
+  INF MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitterDxe.inf
+
+  INF MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsoleDxe.inf
+
+  INF MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
+  INF MdeModulePkg/Universal/SerialDxe/SerialDxe.inf
+
+  INF ArmPkg/Drivers/ArmGic/ArmGicDxe.inf
+  INF ArmPkg/Drivers/TimerDxe/TimerDxe.inf
+
+  INF MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.inf
+
+  INF MdeModulePkg/Universal/PCD/Dxe/Pcd.inf
+
+  #
+  # ACPI Support
+  #
+  INF MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
+  INF MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
+  INF RuleOverride = ACPITABLE Platform/FriendlyElec/NanoPC-T6/AcpiTables/AcpiTables.inf
+
+  #
+  # Device tree
+  #
+  INF EmbeddedPkg/Drivers/DtPlatformDxe/DtPlatformDxe.inf
+  # FILE FREEFORM = 25462CDA-221F-47DF-AC1D-259CFAA4E326 {
+  #   SECTION RAW = Platform/Rockchip/DeviceTree/rk3588.dtb
+  # }
+
+  #
+  # GPIO
+  #
+  INF Platform/Rockchip/RK3588/RK3588GpioDxe/RK3588GpioDxe.inf
+  #INF ArmPlatformPkg/Drivers/PL061GpioDxe/PL061GpioDxe.inf
+
+  #
+  # I2C
+  #
+  INF Silicon/Rockchip/Drivers/I2c/I2cDxe/I2cDxe.inf
+  INF MdeModulePkg/Bus/I2c/I2cDxe/I2cDxe.inf
+  # INF Silicon/Rockchip/Drivers/I2c/I2cDemoDxe/I2cDemoDxe.inf
+  INF Silicon/Rockchip/Drivers/I2c/Rk860xRegulatorDxe/Rk860xRegulatorDxe.inf
+
+  #
+  # Virtual Keyboard
+  #
+  INF EmbeddedPkg/Drivers/VirtualKeyboardDxe/VirtualKeyboardDxe.inf
+
+  #
+  # Display Support
+  #
+  
+  INF Silicon/Rockchip/Drivers/Vop2Dxe/Vop2Dxe.inf
+  #INF Silicon/Rockchip/Library/DisplayLib/AnalogixDpLib.inf
+  INF Silicon/Rockchip/Library/DisplayLib/DwHdmiQpLib.inf
+  INF Silicon/Rockchip/Drivers/LcdGraphicsOutputDxe/LcdGraphicsOutputDxe.inf
+  INF MdeModulePkg/Logo/LogoDxe.inf
+
+  INF Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/RK3588Dxe.inf
+
+  #
+  # SMBIOS Support
+  #
+  INF Silicon/Rockchip/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.inf
+  INF MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf
+
+  #
+  # USB Ehci Controller
+  #
+  INF MdeModulePkg/Bus/Pci/EhciDxe/EhciDxe.inf
+
+  #
+  # USB Ohci Controller
+  #
+  INF Silicon/Rockchip/Drivers/OhciDxe/OhciDxe.inf
+
+  #
+  # USB Dwc3 Controller
+  #
+  INF Silicon/Rockchip/Drivers/UsbHcdInitDxe/UsbHcd.inf
+
+  #
+  # USB Xhci Controller
+  #
+  INF MdeModulePkg/Bus/Pci/XhciDxe/XhciDxe.inf
+
+  #
+  # USB Host Support
+  #
+  INF MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBusDxe.inf
+
+  #
+  # USB Mass Storage Support
+  #
+  INF MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassStorageDxe.inf
+
+  #
+  # USB Kb Support
+  #
+  INF MdeModulePkg/Bus/Usb/UsbKbDxe/UsbKbDxe.inf
+
+  #
+  # USB Mouse Support
+  #
+  INF MdeModulePkg/Bus/Usb/UsbMouseDxe/UsbMouseDxe.inf
+
+  #
+  # USB MouseAbsolutePointer Support
+  #
+  INF MdeModulePkg/Bus/Usb/UsbMouseAbsolutePointerDxe/UsbMouseAbsolutePointerDxe.inf
+
+  #
+  # USB Peripheral Support
+  #
+  INF EmbeddedPkg/Drivers/AndroidFastbootTransportUsbDxe/FastbootTransportUsbDxe.inf
+
+  #
+  # Fastboot
+  #
+  INF EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.inf
+
+
+  #PCIe
+  INF Silicon/Rockchip/Drivers/PciPlatform/PcieInitDxe.inf
+
+  # Required by PCI
+  INF ArmPkg/Drivers/ArmPciCpuIo2Dxe/ArmPciCpuIo2Dxe.inf
+
+  # PCI Support
+  INF MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
+  INF MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
+  INF MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
+  #INF MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPei.inf
+
+  #INF MdeModulePkg/Bus/Usb/UsbKbDxe/UsbKbDxe.inf
+  INF MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.inf
+  INF MdeModulePkg/Bus/Pci/SataControllerDxe/SataControllerDxe.inf
+  INF MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.inf
+
+  #
+  # Android Boot applications
+  #
+  INF EmbeddedPkg/Application/AndroidBoot/AndroidBootApp.inf
+
+  #
+  # UEFI Network Stack
+  #
+!include NetworkPkg/Network.fdf.inc
+
+  #
+  # AX88772 Ethernet Driver for Apple Ethernet Adapter
+  #
+  INF Drivers/ASIX/Bus/Usb/UsbNetworking/Ax88772c/Ax88772c.inf
+
+  #
+  # FAT filesystem + GPT/MBR partitioning
+  #
+  INF MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf
+  INF MdeModulePkg/Universal/Disk/PartitionDxe/PartitionDxe.inf
+  INF MdeModulePkg/Universal/FvSimpleFileSystemDxe/FvSimpleFileSystemDxe.inf
+  INF FatPkg/EnhancedFatDxe/Fat.inf
+  INF MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/EnglishDxe.inf
+
+  #
+  # Multimedia Card Interface
+  #
+  # INF Silicon/Synopsys/DesignWare/Drivers/DwEmmcDxe/DwEmmcDxe.inf
+  INF Silicon/Rockchip/Drivers/MmcDxe/MmcDxe.inf
+  INF Silicon/Rockchip/RK3588/Drivers/DwEmmcDxe/DwEmmcDxe.inf
+  
+  #
+  # DWC SDHCI (for eMMC slot)
+  #
+  INF Silicon/Rockchip/Drivers/SdhciHostDxe/SdhciHostDxe.inf
+
+  #
+  # AHCI Support
+  #
+  INF Silicon/Rockchip/Drivers/SataControllerDxe/SataControllerDxe.inf
+  INF Silicon/Rockchip/Drivers/AtaAtapiPassThru/AtaAtapiPassThru.inf
+  INF MdeModulePkg/Bus/Ata/AtaBusDxe/AtaBusDxe.inf
+
+  #
+  # SPI NOR FLASH
+  #
+  INF Silicon/Rockchip/Drivers/NorFlashDxe/NorFlashDxe.inf
+
+  # Variable services
+  INF Silicon/Rockchip/Drivers/NorFlashDxe/RkFvbDxe.inf
+  INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+  INF MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
+
+  # Human interface
+  INF MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
+
+  # Custom
+  INF Silicon/Rockchip/Applications/MaskromReset/maskrom.inf
+  
+  # SCMI Driver
+  INF ArmPkg/Drivers/ArmScmiDxe/ArmScmiDxe.inf
+
+  #
+  # UEFI applications
+  #
+  INF ShellPkg/Application/Shell/Shell.inf
+!ifdef $(INCLUDE_TFTP_COMMAND)
+  INF ShellPkg/DynamicCommand/TftpDynamicCommand/TftpDynamicCommand.inf
+!endif #$(INCLUDE_TFTP_COMMAND)
+  #INF Silicon/Rockchip/Applications/SpiTool/SpiFlashCmd.inf
+
+  #
+  # Bds
+  #
+  INF MdeModulePkg/Universal/DevicePathDxe/DevicePathDxe.inf
+  INF MdeModulePkg/Universal/SetupBrowserDxe/SetupBrowserDxe.inf
+  INF MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf
+  INF MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
+  INF MdeModulePkg/Application/UiApp/UiApp.inf
+
+  #
+  # Simple Init GUI
+  #
+!if $(ENABLE_SIMPLE_INIT)
+  INF src/main/SimpleInitMain.inf
+!endif
+
+[FV.BL33_AP_UEFI]
+FvAlignment        = 8
+ERASE_POLARITY     = 1
+MEMORY_MAPPED      = TRUE
+STICKY_WRITE       = TRUE
+LOCK_CAP           = TRUE
+LOCK_STATUS        = TRUE
+WRITE_DISABLED_CAP = TRUE
+WRITE_ENABLED_CAP  = TRUE
+WRITE_STATUS       = TRUE
+WRITE_LOCK_CAP     = TRUE
+WRITE_LOCK_STATUS  = TRUE
+READ_DISABLED_CAP  = TRUE
+READ_ENABLED_CAP   = TRUE
+READ_STATUS        = TRUE
+READ_LOCK_CAP      = TRUE
+READ_LOCK_STATUS   = TRUE
+
+  INF ArmPlatformPkg/PrePi/PeiUniCore.inf
+
+  FILE FV_IMAGE = 9E21FD93-9C72-4c15-8C4B-E77F1DB2D792 {
+    SECTION GUIDED EE4E5898-3914-4259-9D6E-DC7BD79403CF PROCESSING_REQUIRED = TRUE {
+      SECTION FV_IMAGE = FVMAIN
+    }
+  }
+
+!include Silicon/Rockchip/Rockchip.fdf.inc
+
+!ifdef $(ROCKCHIP_ACPIEN)
+[Rule.Common.DXE_DRIVER]
+  FILE DRIVER = $(NAMED_GUID) {
+    DXE_DEPEX	 DXE_DEPEX		Optional $(INF_OUTPUT)/$(MODULE_NAME).depex
+    PE32	 PE32			$(INF_OUTPUT)/$(MODULE_NAME).efi
+    UI		 STRING="$(MODULE_NAME)" Optional
+    RAW 	 ACPI  Optional 	      |.acpi
+    RAW 	 ASL   Optional 	      |.aml
+  }
+
+[Rule.Common.USER_DEFINED.ACPITABLE]
+  FILE FREEFORM = $(NAMED_GUID) {
+    RAW ACPI		   |.acpi
+    RAW ASL		   |.aml
+  }
+!endif


### PR DESCRIPTION
It boots into Windows 11 WTG with working usb ports.
This board has SPI Flash solder pads, but doesn't have an SPI Flash soldered on board (at least for now). The EFI image can be flashed into a TF card.

What's working:
- Type-C and USB
- HDMI0 Output
- eMMC and SDHCI

What's broken or untested:
- Everything else